### PR TITLE
fix: vulnerability audit 2026-04-09

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1257,9 +1257,9 @@
             "dev": true
         },
         "node_modules/brace-expansion": {
-            "version": "1.1.12",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-            "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+            "version": "1.1.13",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.13.tgz",
+            "integrity": "sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -1582,10 +1582,11 @@
             }
         },
         "node_modules/diff": {
-            "version": "4.0.2",
-            "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
-            "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
+            "version": "4.0.4",
+            "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.4.tgz",
+            "integrity": "sha512-X07nttJQkwkfKfvTPG/KSnE2OMdcUCao6+eXF3wmnIQRn2aPAHH3VxDbDOdegkd6JbPsXqShpvEOHfAT+nCNwQ==",
             "dev": true,
+            "license": "BSD-3-Clause",
             "engines": {
                 "node": ">=0.3.1"
             }
@@ -1767,9 +1768,9 @@
             }
         },
         "node_modules/filelist/node_modules/brace-expansion": {
-            "version": "2.0.2",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
-            "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
+            "version": "2.0.3",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.3.tgz",
+            "integrity": "sha512-MCV/fYJEbqx68aE58kv2cA/kiky1G8vux3OR6/jbS+jIMe/6fJWa0DTzJU7dqijOWYwHi1t29FlfYI9uytqlpA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -3124,10 +3125,11 @@
             "dev": true
         },
         "node_modules/picomatch": {
-            "version": "2.3.1",
-            "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
-            "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+            "version": "2.3.2",
+            "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+            "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
             "dev": true,
+            "license": "MIT",
             "engines": {
                 "node": ">=8.6"
             },


### PR DESCRIPTION
## Auditoría de vulnerabilidades — 2026-04-09

### Resumen

| Severidad | Antes | Después |
|-----------|-------|---------|
| Critical  | 0     | 0       |
| High      | 1     | 0       |
| Moderate  | 1     | 0       |
| Low       | 1     | 0       |

### Análisis por vulnerabilidad

#### GHSA-c2c7-rcm5-vvqj + GHSA-3v7f-55p6-f55p — picomatch (2.3.1) — HIGH + LOW
- **Severidad:** High (CVSS 7.5) ReDoS via extglob quantifiers + Low (CVSS 5.3) method injection en POSIX character classes
- **Tipo:** Transitiva — `jest@29.7.0 → @jest/core → jest-haste-map → anymatch → picomatch` (devDependency)
- **Impacto en producción:** Ninguno — picomatch solo existe en el toolchain de testing. La librería compilada publicada no incluye picomatch.
- **Fix aplicado:** `npm audit fix` — bump lockfile `picomatch 2.3.1 → 2.3.2` (patch dentro de constraint existente)

#### GHSA-f886-m6hf-6m8v — brace-expansion (2.0.2 + 1.1.12) — MODERATE
- **Severidad:** Moderate (CVSS 6.5) — Zero-step sequence causes process hang (DoS)
- **Tipo:** Transitiva — `ts-jest@29.2.5 → ejs → jake` (devDependency)
- **Impacto en producción:** Ninguno — solo en toolchain de testing
- **Fix aplicado:** `npm audit fix` — bumps `brace-expansion 2.0.2 → 2.0.3` y `1.1.12 → 1.1.13`

#### (no CVE) — diff (4.0.2) — LOW
- **Severidad:** Low — DoS en `parsePatch` y `applyPatch`
- **Tipo:** Transitiva — `ts-node@10.9.2 → diff` (devDependency)
- **Impacto en producción:** Ninguno — usado por ts-node para stack traces durante desarrollo
- **Fix aplicado:** `npm audit fix` — bump `diff 4.0.2 → 4.0.4`

### Nota sobre los cambios

Solo se modificó `package-lock.json`. No se realizaron cambios en `package.json` ya que todos los bumps están dentro de los rangos semver existentes.

### Cómo verificar

```bash
git checkout fix/audit-2026-04-09
npm install
npm audit  # debe mostrar 0 vulnerabilidades
```