### PR TITLE
feat(logger): stop duplicating msg in live (CloudWatch) logs

### DIFF
--- a/__tests__/LoggerFactory.test.ts
+++ b/__tests__/LoggerFactory.test.ts
@@ -1,10 +1,50 @@
-import { beforeEach, describe, it, jest } from '@jest/globals';
+import { beforeEach, describe, it, jest, expect } from '@jest/globals';
 
 import { mkdtempSync } from 'fs';
 import { readFile } from 'node:fs/promises';
 import * as path from 'node:path';
 import * as os from 'node:os';
-import { DevLoggerManager } from '../logger/LoggerFactory';
+import { CloudwatchDedupedFormatter, DevLoggerManager } from '../logger/LoggerFactory';
+
+describe('CloudwatchDedupedFormatter', () => {
+    const formatter = new CloudwatchDedupedFormatter();
+
+    it('keeps msg in the text column but omits it from the JSON payload', () => {
+        const output = formatter.format({
+            awsRequestId: 'req-123',
+            level: 20,
+            msg: 'event: {"huge":"payload"}',
+            name: 'OnCertificateChanged',
+            foo: 'bar',
+        } as never);
+
+        const fields = output.split('\t');
+        const json = JSON.parse(fields[fields.length - 1]);
+
+        // text column still carries the message (4th field: time, reqId, LEVEL, msg)
+        expect(fields[1]).toBe('req-123');
+        expect(fields[2]).toBe('DEBUG');
+        expect(fields[3]).toBe('event: {"huge":"payload"}');
+
+        // ...but it is no longer duplicated inside the JSON payload
+        expect(json.msg).toBeUndefined();
+
+        // every other field is preserved
+        expect(json.name).toBe('OnCertificateChanged');
+        expect(json.foo).toBe('bar');
+        expect(json.level).toBe(20);
+    });
+
+    it('omits the requestId tab when there is no awsRequestId', () => {
+        const output = formatter.format({ level: 30, msg: 'hello' } as never);
+        const fields = output.split('\t');
+
+        // time, LEVEL, msg, json  -> no requestId field
+        expect(fields[1]).toBe('INFO');
+        expect(fields[2]).toBe('hello');
+        expect(JSON.parse(fields[3]).msg).toBeUndefined();
+    });
+});
 
 describe('LoggerFactory', () => {
     const oldEnv = { ...process.env };

--- a/logger/LoggerFactory.ts
+++ b/logger/LoggerFactory.ts
@@ -1,8 +1,38 @@
 import { destination, Level, Logger as PinoLoggerImpl, pino } from 'pino';
-import { pinoLambdaDestination } from 'pino-lambda';
+import { pinoLambdaDestination, ILogFormatter, LogData } from 'pino-lambda';
 import { pinoCaller } from 'pino-caller';
 import { PinoPretty as pretty } from 'pino-pretty';
 import { getLoggerPackage } from './PackageLoggers';
+
+/**
+ * Same line layout as pino-lambda's default CloudwatchLogFormatter
+ * (`<time> <requestId> <LEVEL> <msg> <json>`) but omitting `msg` from the
+ * trailing JSON payload, since it is already present in the text column.
+ * This avoids logging the (often large) message twice on every log line.
+ */
+export class CloudwatchDedupedFormatter implements ILogFormatter {
+    private static readonly LEVEL_LABELS: Record<number, string> = {
+        10: 'TRACE',
+        20: 'DEBUG',
+        30: 'INFO',
+        40: 'WARN',
+        50: 'ERROR',
+        60: 'FATAL',
+    };
+
+    private static formatLevel(level: string | number): string {
+        return typeof level === 'number'
+            ? (CloudwatchDedupedFormatter.LEVEL_LABELS[level] ?? String(level))
+            : String(level).toUpperCase();
+    }
+
+    format(data: LogData): string {
+        const { msg, ...rest } = data as LogData & Record<string, unknown>;
+        const time = new Date().toISOString();
+        const levelTag = CloudwatchDedupedFormatter.formatLevel(data.level);
+        return `${time}${data.awsRequestId ? `\t${data.awsRequestId}` : ''}\t${levelTag}\t${msg ?? ''}\t${JSON.stringify(rest)}`;
+    }
+}
 
 /* eslint-disable @typescript-eslint/no-explicit-any */
 export interface Logger {
@@ -229,7 +259,9 @@ export class LiveLoggerManager implements LoggerManager {
     }
 
     createRoot(): PinoLogger {
-        return new PinoLogger(pino({ level: this.defaultLevel }, pinoLambdaDestination()));
+        return new PinoLogger(
+            pino({ level: this.defaultLevel }, pinoLambdaDestination({ formatter: new CloudwatchDedupedFormatter() })),
+        );
     }
 
     create(name: string, opts?: LoggerOptions): Logger {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@yopdev/logging",
-    "version": "0.0.9",
+    "version": "0.0.10",
     "description": "A simple pino wrapper for Node.js",
     "scripts": {
         "compile": "tsc",


### PR DESCRIPTION
## Problem

The default `pino-lambda` `CloudwatchLogFormatter` writes every log line as:

```
<time>  <requestId>  <LEVEL>  <msg>  <json>
```

…where the trailing JSON payload **also** contains `msg`. So the message text is written **twice on every line**.

This is most expensive for SQS handlers that log the whole event via `logSqsEvent` → `logger.debug('event: %o', event)`: the entire SQS+SNS envelope (signature, `SigningCertURL`, the triple-escaped `Message`, etc.) is duplicated on **every record**, at DEBUG level, across **~30 handlers in ~13 services**.

## Change

Add `CloudwatchDedupedFormatter`:
- **Identical text layout** to the default formatter (`<time> <requestId> <LEVEL> <msg> <json>`), so any CloudWatch metric filter / query that parses the text column keeps working.
- **Omits `msg` from the JSON payload** — it's already in the text column. Every other field (`level`, `time`, `name`, `pid`, `hostname`, structured fields) is preserved.

Wired into `LiveLoggerManager` only. Dev mode (`pino-pretty`) is unchanged.

### Before / after (live output)

```
BEFORE  …DEBUG  event:{…4KB…}   {"level":20,…,"name":"…","msg":"event:{…4KB…}"}
AFTER   …DEBUG  event:{…4KB…}   {"level":20,…,"name":"…"}
                                                          └ no longer repeats the payload
```

## Trade-off

`msg` is no longer a key of the JSON object. Logs Insights queries that filter the **parsed** `msg` field would need to read the text column (`@message`) instead. The data is not lost — only its location changes.

## Tests

- New unit tests for `CloudwatchDedupedFormatter` (msg in text column, absent from JSON, other fields preserved, no-requestId case).
- Existing suite untouched. `tsc --noEmit` clean, `jest` 9/9.
- Verified end-to-end against a real `LiveLoggerManager` instance.

Bumps version `0.0.9 → 0.0.10`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)