### PR TITLE
fix: vulnerability audit 2026-06-29

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2771,9 +2771,9 @@
             "dev": true
         },
         "node_modules/js-yaml": {
-            "version": "3.14.2",
-            "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.2.tgz",
-            "integrity": "sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg==",
+            "version": "3.15.0",
+            "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.0.tgz",
+            "integrity": "sha512-ttBQIIQPDeLjpPOohtUdXuXUVoA2uIB6fEH9HyJ7234s5mBJ5wTx20njxplLZQgLaOfpmPQA7X2t5AX6tIPbog==",
             "dev": true,
             "license": "MIT",
             "dependencies": {

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
         "prettier": "^3.7.4"
     },
     "overrides": {
-        "@babel/core": ">=7.29.6 <8"
+        "@babel/core": ">=7.29.6 <8",
+        "js-yaml@3": ">=3.15.0 <4"
     }
 }


### PR DESCRIPTION
## Vulnerability audit — 2026-06-29

### Summary

| Severity | Before | After |
|----------|--------|-------|
| Critical | 0 | 0 |
| High     | 0 | 0 |
| Moderate | 1 | 0 |
| Low      | 0 | 0 |

### Analysis per vulnerability

#### CVE-2026-53550 — js-yaml (`<3.15.0`) — MODERATE → fixed
- **Type:** transitive devDependency via the Jest/Babel coverage chain (`jest > babel-plugin-istanbul > @istanbuljs/load-nyc-config > js-yaml`).
- **Production impact:** Low — js-yaml 3.x is only present in the test/coverage tooling, never in shipped/runtime code (the project's own `js-yaml` direct usage, where any, is on 4.x which is unaffected).
- **Vulnerability:** quadratic-complexity DoS in YAML merge-key handling via repeated aliases.
- **Fix applied:** added override `js-yaml@3: >=3.15.0 <4`.
- **Verification:** re-ran the audit after reinstall — resolved `js-yaml@3` is now `3.15.0`; 0 vulnerabilities remain. No new advisories introduced.

### How to verify

```bash
git checkout fix/audit-2026-06-29
npm ci
npm audit   # 0 vulnerabilities
```